### PR TITLE
inject a custom RNG function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,41 @@ I am a happy iguana.
 I am an angry fox.
 I am a sad capybara.
 ```
+
+### Making Tracery deterministic
+
+By default, Tracery uses Math.random() to generate random numbers. If you need Tracery to be deterministic, you can make it use your own random number generator using:
+
+    tracery.setRng(myRng);
+
+where myRng is a function that, [like Math.random()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random), returns a floating-point, pseudo-random number in the range [0, 1).
+
+By using a local random number generator that takes a seed and controlling this seed, you can make Tracery's behavior completely deterministic.
+
+
+```javascript
+// Stable random number generator
+// Copied from this excellent answer on Stack Overflow: https://stackoverflow.com/a/47593316/3306
+function splitmix32(seed) {
+  return function() {
+    seed |= 0; // bitwise OR ensures this is treated as an integer internally for performance.
+    seed = seed + 0x9e3779b9 | 0; // again, bitwise OR for performance 
+    let t = seed ^ seed >>> 16;
+    t = Math.imul(t, 0x21f0aaad);
+    t = t ^ t >>> 15;
+    t = Math.imul(t, 0x735a2d97);
+    return ((t = t ^ t >>> 15) >>> 0) / 4294967296;
+  };
+}
+
+var seed = 123456;
+tracery.setRng(splitmix32(seed));
+
+console.log(grammar.flatten('#origin#'));
+```
+
+Deterministic output:
+
+```plaintext
+I am an angry capybara.
+```

--- a/tracery.js
+++ b/tracery.js
@@ -3,6 +3,11 @@
  */
 
 var tracery = function() {
+    var rng = Math.random;
+
+    var setRng = function setRng(newRng) {
+        rng = newRng;
+    }
 
     var TraceryNode = function(parent, childIndex, settings) {
         this.errors = [];
@@ -362,7 +367,7 @@ var tracery = function() {
                 break;
             default:
 
-                index = Math.floor(Math.pow(Math.random(), this.falloff) * this.defaultRules.length);
+                index = Math.floor(Math.pow(rng(), this.falloff) * this.defaultRules.length);
                 break;
             }
 
@@ -393,7 +398,7 @@ var tracery = function() {
         while (0 !== currentIndex) {
 
             // Pick a remaining element...
-            randomIndex = Math.floor(Math.random() * currentIndex);
+            randomIndex = Math.floor(rng() * currentIndex);
             currentIndex -= 1;
 
             // And swap it with the current element.
@@ -855,6 +860,9 @@ var tracery = function() {
     tracery.Grammar = Grammar;
     tracery.Symbol = Symbol;
     tracery.RuleSet = RuleSet;
+
+    tracery.setRng = setRng;
+
     return tracery;
 }();
 


### PR DESCRIPTION
Please review my pull request to inject a stable random number generator into tracery. This is a feature that is available on the tracery2 branch upstream, and can be helpful if you want to generate predictable output based on a seed.

I followed the original commit by Jurie Horneman (https://github.com/galaxykate/tracery/commit/3a34535b55942b0eb1fd9965105a6fbcbf0cd20e), but due to the divergence with upstream, I had to re-apply it from scratch.

In the documentation, I've added a more elaborate example.